### PR TITLE
Change header social link markup

### DIFF
--- a/ssi/utility-header.html
+++ b/ssi/utility-header.html
@@ -4,13 +4,13 @@
             <div class="half">
                 <ul class="utility-links social-media-links">
                    
-                    <li><a href="/"><span class="ca-gov-icon-home" aria-hidden="true"></span><span class="sr-only">Home</span></a></li>
-                    
+                    <li><a class="ca-gov-icon-home" href="/"><span class="sr-only">Home</span></a></li>
                   
-                    <li><a class="ca-gov-icon-facebook" title="Facebook channel" tabindex="0" href=""></a></li>
-                    <li><a class="ca-gov-icon-twitter" title="Twitter channel" tabindex="0" href=""></a></li>
-                    <li><a class="ca-gov-icon-google-plus" title="Google+ channel" tabindex="0" href=""></a></li>
-                    <li><a class="ca-gov-icon-email" title="email" tabindex="0" href=""></a></li>
+                    <li><a class="ca-gov-icon-facebook" href=""><span class="sr-only">Facebook</span></a></li>
+                    <li><a class="ca-gov-icon-twitter" href=""><span class="sr-only">Twitter</span></a></li>
+                    <li><a class="ca-gov-icon-google-plus" href=""><span class="sr-only">Google Plus</span></a></li>
+                    <li><a class="ca-gov-icon-email" href=""><span class="sr-only">Email</span></a></li>
+                    
                 </ul>
             </div>
             <div class="half settings-links">


### PR DESCRIPTION
[The `title` attribute is inconsistently used by assistive technologies](https://silktide.com/i-thought-title-text-improved-accessibility-i-was-wrong/). I tested this markup in the JAWS and NVDA screen readers, both of which initially read each social link as merely "visited link." Only when I tabbed to the link did the screen readers read the `title` attribute.

I recommend using the same markup pattern as the home icon, which will be properly read by screen readers.

Also, the `tabindex` attributes seem to be unnecessary: links are already focusable.